### PR TITLE
Implement page scrolling

### DIFF
--- a/hex_viewer.c
+++ b/hex_viewer.c
@@ -250,6 +250,23 @@ int32_t hex_viewer_app(void* p) {
                     if(!hex_viewer_read_file(hex_viewer)) break;
                 }
                 furi_mutex_release(hex_viewer->mutex);
+            } else if(input.key == InputKeyOk) {
+                furi_check(furi_mutex_acquire(hex_viewer->mutex, FuriWaitForever) == FuriStatusOk);
+                uint32_t last_byte_on_screen =
+                    hex_viewer->model->file_offset + hex_viewer->model->file_read_bytes;
+
+                if(hex_viewer->model->file_size > last_byte_on_screen) {
+                    uint32_t bytes_left_offscreen = hex_viewer->model->file_size -
+                                                    hex_viewer->model->file_offset -
+                                                    hex_viewer->model->file_read_bytes;
+                    uint32_t lines_to_scroll =
+                        MIN(HEX_VIEWER_LINES_ON_SCREEN,
+                            (bytes_left_offscreen + HEX_VIEWER_BYTES_PER_LINE - 1) /
+                                HEX_VIEWER_BYTES_PER_LINE);
+                    hex_viewer->model->file_offset += lines_to_scroll * HEX_VIEWER_BYTES_PER_LINE;
+                    if(!hex_viewer_read_file(hex_viewer)) break;
+                }
+                furi_mutex_release(hex_viewer->mutex);
             } else if(input.key == InputKeyLeft) {
                 furi_check(furi_mutex_acquire(hex_viewer->mutex, FuriWaitForever) == FuriStatusOk);
                 hex_viewer->model->mode = !hex_viewer->model->mode;


### PR DESCRIPTION
Hi,

Firstly, I would like to thank you for your work on this app.

When scrolling through bigger files, the single line scrolling feature using the down key is very slow and it takes a lot of time to reach the of of the file.

For this reason, I have implemented a page scrolling down feature using the OK button, similar to how you can scroll down a page in a terminal or web browser using the space bar.

There are however some disadvantages with this approach:

1. Reaching the end of a file in very large files might still take long.
   Solution A: A _jump to address_ feature.
   Solution B: Gradually decreasing delay between page scrolls (if possible). This would over-complicate things a lot.
2. This only implements scrolling down in pages, not upwards, like you can do by holding shift while pressing the space bar in a browser.
   Solution A: Page scrolling can be done while holding the OK button and pressing the up/down buttons.
   Solution B: Page scrolling/line scrolling can be toggled by pressing the OK button.
3. Page scrolling doesn't align to multiples of `BUF_SIZE`. For example if you single line scroll to address `0004` page scrolling down scrolls to address `0014` assuming standard constants.
   This is in my opinion intended behavior and shouldn't be changed.

I'd love to hear your feedback and suggestions on what would be the best option. This PR can be viewed as a PoC. However if you like the current implementation feel free to merge it.

Thanks a lot