### PR TITLE
Fix crash on exit

### DIFF
--- a/hex_viewer.c
+++ b/hex_viewer.c
@@ -97,6 +97,7 @@ void hex_viewer_app_free(HexViewer* app) {
 
     // View Dispatcher
     view_dispatcher_remove_view(app->view_dispatcher, HexViewerViewIdMenu);
+    view_dispatcher_remove_view(app->view_dispatcher, HexViewerViewIdStartscreen);
     view_dispatcher_remove_view(app->view_dispatcher, HexViewerViewIdScroll);
     view_dispatcher_remove_view(app->view_dispatcher, HexViewerViewIdSettings);
 


### PR DESCRIPTION
`HexViewerIdStartscreen` was not being removed and causing a `furi_check` to fail.